### PR TITLE
投稿時に不足項目があると警告表示させる

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -15,7 +15,8 @@ class PrototypesController < ApplicationController
     if @prototype.save
       redirect_to :root, notice: 'New prototype was successfully created'
     else
-      redirect_to ({ action: new }), alert: 'YNew prototype was unsuccessfully created'
+      flash[:alert] = 'YNew prototype was unsuccessfully created'
+      render :new
      end
   end
 


### PR DESCRIPTION
prototypeコントローラーにflashとrenderを指定。
WHAT 投稿時に不足時だと警告する WHY 基本機能のため